### PR TITLE
Kademlia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,10 +479,12 @@ dependencies = [
 name = "golem_libp2p"
 version = "0.1.0"
 dependencies = [
+ "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.3.1 (git+https://github.com/libp2p/rust-libp2p?rev=eeed66707b483448d641b9824a8f726121c5a334)",
  "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-stdin-stdout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1776,6 +1778,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stdin-stdout"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-sync"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2237,7 @@ dependencies = [
 "checksum tokio-fs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e9cbbc8a3698b7ab652340f46633364f9eaa928ddaaee79d8b8f356dd79a09d"
 "checksum tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b53aeb9d3f5ccf2ebb29e19788f96987fa1355f8fe45ea193928eaaaf3ae820f"
 "checksum tokio-reactor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "afbcdb0f0d2a1e4c440af82d7bbf0bf91a8a8c0575bcd20c05d15be7e9d3a02f"
+"checksum tokio-stdin-stdout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc480d205310fa52f8ea65e7f9443568b6b342f326e86431d2aeb176d720c17"
 "checksum tokio-sync 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3742b64166c1ee9121f1921aea5a726098458926a6b732d906ef23b1f3ef6f4f"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c3fd86cb15547d02daa2b21aadaf4e37dee3368df38a526178a5afa3c034d2fb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,18 @@ authors = ["Adam Wierzbicki <awierzbicki@golem.network>"]
 edition = "2018"
 
 [dependencies]
+bs58 = "0.2"
 futures = "0.1"
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "eeed66707b483448d641b9824a8f726121c5a334" }
 tokio = "0.1"
 tokio-io = "0.1"
+tokio-stdin-stdout = "0.1"
 void = "1.0"
 
 [[bin]]
 name = "welcome"
 path = "src/bin/welcome_demo.rs"
+
+[[bin]]
+name = "kademlia"
+path = "src/bin/kad_demo.rs"

--- a/kad_test.py
+++ b/kad_test.py
@@ -1,0 +1,91 @@
+import random
+import subprocess
+import sys
+import time
+from typing import Dict, List, Tuple
+
+BIN_PATH = './target/debug/kademlia.exe'
+
+
+def run_kad_demo(listen_port, dial_port=None) -> Tuple[str, subprocess.Popen]:
+    cmd = [BIN_PATH, str(listen_port)]
+    if dial_port is not None:
+        cmd += [str(dial_port)]
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        universal_newlines=True
+    )
+    peer_id = proc.stdout.readline().strip('\n')
+
+    return peer_id, proc
+
+
+def format_addr(port) -> str:
+    return f"/ip4/127.0.0.1/tcp/{port}"
+
+
+def format_result(peer_id, addr) -> str:
+    return f"{peer_id} : {addr}"
+
+
+def run(num_peers=10, num_queries=5, start_port=54321, random_connect=True):
+
+    peer_ids: List[str] = []
+    addresses: Dict[str, str] = {}
+    processes: Dict[str, subprocess.Popen] = {}
+
+    print("Spawning processes...")
+
+    for port in range(start_port, start_port + num_peers):
+        if port > start_port:
+            if random_connect:
+                dial_port = random.randint(start_port, port - 1)
+            else:
+                dial_port = start_port
+        else:
+            dial_port = None
+
+        peer_id, proc = run_kad_demo(port, dial_port)
+        peer_ids.append(peer_id)
+        processes[peer_id] = proc
+        addresses[peer_id] = format_addr(port)
+        print(f"Node {peer_id} listening on addr {addresses[peer_id]} "
+              f"dialing addr {format_addr(dial_port)}")
+
+    queries: Dict[str, List[str]] = {}
+
+    print("Querying for node addresses...")
+
+    for peer_id in peer_ids:
+        queries[peer_id] = []
+        for _ in range(num_queries):
+            query = random.choice(peer_ids)
+            queries[peer_id].append(query)
+            processes[peer_id].stdin.write(query + '\n')
+            print(f"Node {peer_id} querying for address of node {query}")
+
+    print("Sleeping...")
+    time.sleep(num_peers)
+
+    print("Checking query outputs...")
+    test_ok = True
+    for peer_id in peer_ids:
+        output, _ = processes[peer_id].communicate(timeout=5)
+        for query in queries[peer_id]:
+            result = format_result(query, addresses[query])
+            if result not in output:
+                test_ok = False
+                print(f"Result '{result}' not found in output of peer {peer_id}")
+
+    if test_ok:
+        print("OK")
+    else:
+        print("Failed")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    run(*map(int, sys.argv[1:]))

--- a/src/behaviour/kad.rs
+++ b/src/behaviour/kad.rs
@@ -1,0 +1,89 @@
+use std::ops::{Deref, DerefMut};
+
+use futures::Async;
+
+use libp2p::{PeerId, kad, Multiaddr};
+use libp2p::core::protocols_handler::{ProtocolsHandler};
+use libp2p::core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
+pub use libp2p::kad::KademliaOut;
+
+use tokio::prelude::{AsyncRead, AsyncWrite};
+
+pub struct Kademlia<TSubstream> {
+    local_peer_id: PeerId,
+    kademlia: kad::Kademlia<TSubstream>
+}
+
+impl <TSubstream> Kademlia<TSubstream> {
+    pub fn new(local_peer_id: PeerId) -> Self {
+        Kademlia {
+            local_peer_id: local_peer_id.clone(),
+            kademlia: kad::Kademlia::new(local_peer_id)
+        }
+    }
+}
+
+impl<TSubstream> Deref for Kademlia<TSubstream> {
+    type Target = kad::Kademlia<TSubstream>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.kademlia
+    }
+}
+
+impl<TSubstream> DerefMut for Kademlia<TSubstream> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.kademlia
+    }
+}
+
+impl<TSubstream> NetworkBehaviour for Kademlia<TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite
+{
+    type ProtocolsHandler = <kad::Kademlia<TSubstream> as NetworkBehaviour>::ProtocolsHandler;
+    type OutEvent = <kad::Kademlia<TSubstream> as NetworkBehaviour>::OutEvent;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        self.kademlia.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.kademlia.addresses_of_peer(peer_id)
+    }
+
+    fn inject_connected(&mut self, peer_id: PeerId, endpoint: ConnectedPoint) {
+        self.kademlia.inject_connected(peer_id.clone(), endpoint.clone());
+
+        // ********************************************************
+        // *** THESE ARE THE ONLY IMPORTANT LINES IN THIS FILE  ***
+        // ***          THE REST IS JUST BOILERPLATE            ***
+        // *** WITHOUT THESE INITIAL QUERIES NODES WOULD NOT BE ***
+        // ***           ABLE TO LOCATE EACH OTHER              ***
+        // ********************************************************
+        match endpoint {
+            ConnectedPoint::Listener {..} => self.kademlia.find_node(peer_id),
+            ConnectedPoint::Dialer {..} => self.kademlia.find_node(self.local_peer_id.clone()),
+        }
+
+    }
+
+    fn inject_disconnected(&mut self, peer_id: &PeerId, endpoint: ConnectedPoint) {
+        self.kademlia.inject_disconnected(peer_id, endpoint)
+    }
+
+    fn inject_replaced(&mut self, peer_id: PeerId, endpoint: ConnectedPoint, new_endpoint: ConnectedPoint) {
+        self.kademlia.inject_replaced(peer_id, endpoint, new_endpoint)
+    }
+
+    fn inject_node_event(&mut self, source: PeerId, event: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent) {
+        self.kademlia.inject_node_event(source, event)
+    }
+
+    fn poll(&mut self, parameters: &mut PollParameters) -> Async<
+        NetworkBehaviourAction<
+            <Self::ProtocolsHandler as ProtocolsHandler>::InEvent, Self::OutEvent>>
+    {
+        self.kademlia.poll(parameters)
+    }
+}

--- a/src/behaviour/mod.rs
+++ b/src/behaviour/mod.rs
@@ -1,2 +1,3 @@
+pub mod kad;
 pub mod reconnect;
 pub mod welcome;

--- a/src/bin/kad_demo.rs
+++ b/src/bin/kad_demo.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+use std::env;
+
+use futures::Async;
+use futures::future::poll_fn;
+use futures::stream::Stream;
+
+use libp2p::core::{Multiaddr, Swarm, PeerId};
+use libp2p::secio::SecioKeyPair;
+use libp2p::tokio_codec::{FramedRead, LinesCodec};
+
+use tokio;
+
+use golem_libp2p::behaviour::kad::{Kademlia, KademliaOut};
+
+fn main() {
+    let local_private_key = SecioKeyPair::ed25519_generated().unwrap();
+    let local_peer_id = local_private_key.to_peer_id();
+    println!("{}", local_peer_id.to_base58());
+
+    let transport = libp2p::build_development_transport(local_private_key);
+    let kademlia = Kademlia::new(local_peer_id.clone());
+    let mut swarm = Swarm::new(transport, kademlia, local_peer_id.clone());
+
+    let args: Vec<String> = env::args().collect();
+
+    let port = args[1].parse::<u16>().unwrap();
+    let addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port).parse().unwrap();
+    Swarm::listen_on(&mut swarm, addr.clone()).unwrap();
+
+    if args.len() > 2 {
+        let port = args[2].parse::<u16>().unwrap();
+        let addr = format!("/ip4/127.0.0.1/tcp/{}", port).parse().unwrap();
+        Swarm::dial_addr(&mut swarm, addr).unwrap();
+    }
+
+    let stdin = tokio_stdin_stdout::stdin(0);
+    let mut framed_stdin = FramedRead::new(stdin, LinesCodec::new());
+
+    let mut peer_addresses = HashMap::new();
+    peer_addresses.insert(local_peer_id, addr);
+
+    tokio::run(poll_fn(move || {
+        loop {
+            match framed_stdin.poll().unwrap() {
+                Async::Ready(Some(line)) => {
+                    let decoded = bs58::decode(line).into_vec().unwrap();
+                    let peer_id = PeerId::from_bytes(decoded).unwrap();
+
+                    match peer_addresses.get(&peer_id) {
+                        Some(addr) => println!("{} : {}", peer_id.to_base58(), addr),
+                        None => swarm.find_node(peer_id)
+                    }
+                },
+                Async::Ready(None) => return Ok(Async::Ready(())),
+                Async::NotReady => break
+            }
+        }
+
+        loop {
+            match swarm.poll().unwrap() {
+                Async::Ready(Some(KademliaOut::Discovered { peer_id, mut addresses, .. })) => {
+                    if addresses.len() > 0 && !peer_addresses.contains_key(&peer_id) {
+                        let addr = addresses.remove(0);
+                        println!("{} : {}", peer_id.to_base58(), addr);
+                        peer_addresses.insert(peer_id, addr);
+                    }
+                }
+                Async::Ready(None) | Async::NotReady => break,
+                _ => {}
+            }
+        }
+
+        Ok(Async::NotReady)
+    }));
+
+}


### PR DESCRIPTION
## Kademlia PoC

To run the demo:
```
./target/debug/kademlia.exe <listen_port> [<dial_port>]
```
* The process will print the running peer ID in the first output line.
* For each peer ID provided via the standard input the node will look for address.
* For each discovered address the process will print a line:
    ```<peer_id> : <address>```
* Send `EOF` for graceful shutdown (<kbd>Ctrl</kbd>+<kbd>D</kbd> on Linux, <kbd>Ctrl</kbd>+<kbd>Z</kbd> on Windows).
* On shutdown the process will print the total number of events processed to standard **error** output.

---

To run the test script:
```
python kad_test.py [<num_peers> [<num_queries> [<start_port>]]]
```
It will spawn `<num_peers>` nodes on ports starting from `<start_port>`. Each node will try to connect to another randomly chosen node (from the ones spawned before). Then each node will try to look for addresses of `<num_queries>` randomly chosen nodes (from all nodes). The test script will check if addresses of the queried nodes appeared in the querying node's output. It will also print the total number of events emitted during test.

---

Results of test runs:

| number of nodes | total messages sent | messages per node |
|-----------------|---------------------|-------------------|
|               5 |                 155 |                31 |
|              10 |                2559 |             255.9 |
|              15 |               12911 |             860.7 |
|              20 |               40390 |            2019.5 |
|              25 |               89065 |            3562.6 |
|              30 |              149350 |            4978.3 |
|              35 |              210333 |            6009.5 |
|              40 |              269002 |            6725.1 |

⚠️ Above 25 nodes the test sometimes failed (i.e. some addresses were not discovered)