### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Golem repostiory with libp2p usage
 
-[Golem](https://github.com/golemfactory/golem/) usage of [libp2p rust implementation](https://github.com/rust-libp2p). 
+[Golem](https://github.com/golemfactory/golem/) usage of [libp2p rust implementation](https://github.com/libp2p/rust-libp2p). 


### PR DESCRIPTION
Update url from `https://github.com/rust-libp2p` to `https://github.com/libp2p/rust-libp2p`